### PR TITLE
Add account model and user role scaffolding

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,19 @@
 
 class ApplicationController < ActionController::API
   include ParameterObjects
+
+  before_action :set_current_account
+  before_action :set_current_user
+
+  private
+
+  def set_current_account
+    subdomain = request.subdomains.first
+    Current.account = Account.find_by(subdomain: subdomain) if subdomain.present?
+    Current.account ||= Account.first
+  end
+
+  def set_current_user
+    Current.user = current_user if defined?(current_user)
+  end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Account < ApplicationRecord
+  has_many :users, dependent: :destroy
+
+  validates :name, presence: true
+  validates :subdomain, presence: true, uniqueness: true
+end

--- a/app/models/concerns/account_scoped.rb
+++ b/app/models/concerns/account_scoped.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module AccountScoped
+  extend ActiveSupport::Concern
+
+  included do
+    belongs_to :account
+    default_scope { where(account_id: Current.account.id) if Current.account }
+  end
+end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Current < ActiveSupport::CurrentAttributes
+  attribute :user, :account
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,4 +2,7 @@
 
 class User < ApplicationRecord
   include Authenticable
+  include AccountScoped
+
+  enum role: { admin: 0, rep: 1, manager: 2 }
 end

--- a/app/services/users/create_service.rb
+++ b/app/services/users/create_service.rb
@@ -9,5 +9,12 @@ module Users
 
       Success(user)
     end
+
+    private
+
+    def params
+      account = Current.account || Account.first || Account.create!(name: 'Default', subdomain: 'default')
+      super.merge(account:, role: :rep)
+    end
   end
 end

--- a/db/migrate/20240701000000_create_accounts.rb
+++ b/db/migrate/20240701000000_create_accounts.rb
@@ -1,0 +1,10 @@
+class CreateAccounts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :accounts, id: :uuid do |t|
+      t.string :name, null: false
+      t.string :subdomain, null: false
+      t.timestamps
+    end
+    add_index :accounts, :subdomain, unique: true
+  end
+end

--- a/db/migrate/20240701001000_add_account_and_role_to_users.rb
+++ b/db/migrate/20240701001000_add_account_and_role_to_users.rb
@@ -1,0 +1,6 @@
+class AddAccountAndRoleToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :users, :account, type: :uuid, null: false, foreign_key: true
+    add_column :users, :role, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_02_12_195921) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_01_001000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -43,6 +43,14 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_12_195921) do
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 
+  create_table "accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name", null: false
+    t.string "subdomain", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["subdomain"], name: "index_accounts_on_subdomain", unique: true
+  end
+
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -56,9 +64,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_12_195921) do
     t.string "last_sign_in_ip"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "account_id", null: false
+    t.integer "role", default: 0, null: false
+    t.index ["account_id"], name: "index_users_on_account_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
+  add_foreign_key "users", "accounts"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
-#   Character.create(name: "Luke", movie: movies.first)
+
+demo_account = Account.find_or_create_by!(name: 'Demo', subdomain: 'demo')
+
+User.find_or_create_by!(email: 'admin@example.com') do |user|
+  user.password = 'password'
+  user.role = :admin
+  user.account = demo_account
+end

--- a/test/factories/accounts_factory.rb
+++ b/test/factories/accounts_factory.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :account do
+    sequence(:name) { |n| "Account #{n}" }
+    sequence(:subdomain) { |n| "account#{n}" }
+  end
+end

--- a/test/factories/users_factory.rb
+++ b/test/factories/users_factory.rb
@@ -2,7 +2,9 @@
 
 FactoryBot.define do
   factory :user do
-    email { Faker::Internet.email }
-    password { Faker::Internet.password(min_length: 6) }
+    sequence(:email) { |n| "user#{n}@example.com" }
+    password { 'password' }
+    association :account
+    role { :admin }
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -11,4 +11,7 @@ class UserTest < ActiveSupport::TestCase
     should have_db_index(:email).unique(true)
     should have_db_index(:reset_password_token).unique(true)
   end
+
+  should belong_to(:account)
+  should define_enum_for(:role).with_values(%i[admin rep manager])
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,6 +27,10 @@ class ActiveSupport::TestCase
   include Supports::ContractValidator
   include Supports::DoorkeeperAuthenticator
   include Supports::SidekiqMinitestSupport
+
+  setup do
+    Current.account = Account.first || create(:account)
+  end
 end
 
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
## Summary
- add Account model with subdomain support and default account scoping
- add role enum and account association to User
- seed demo account and admin user

## Testing
- `bin/rails db:migrate` *(fails: https://github.com/faker-ruby/faker.git is not yet checked out)*
- `bin/rails test` *(fails: https://github.com/faker-ruby/faker.git is not yet checked out)*

------
https://chatgpt.com/codex/tasks/task_e_689c448ce4988326a7c0809248bae8bd