### PR TITLE
Add lead model with sequential numbering

### DIFF
--- a/app/controllers/v1/leads_controller.rb
+++ b/app/controllers/v1/leads_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module V1
+  class LeadsController < ApplicationController
+    def index
+      render json: Lead.all
+    end
+
+    def create
+      lead = Lead.new(lead_params)
+      if lead.save
+        render json: lead, status: :created
+      else
+        render json: { errors: lead.errors.full_messages }, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def lead_params
+      params.require(:lead).permit(:project_name, :job_type, :spa_type, :vanishing_edge,
+                                   :rep_id, :client_request_date, :site_address,
+                                   :customer_name, :customer_phone, :customer_email, :council)
+    end
+  end
+end

--- a/app/models/lead.rb
+++ b/app/models/lead.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class Lead < ApplicationRecord
+  include AccountScoped
+
+  belongs_to :rep, class_name: 'User'
+
+  validates :project_name, :job_type, :spa_type, :rep, :client_request_date,
+            :site_address, :customer_name, :customer_phone, :customer_email,
+            :council, presence: true
+  validates :customer_no, uniqueness: { scope: :account_id }
+  validates :job_no, uniqueness: { scope: :account_id }
+
+  before_validation :assign_numbers, on: :create
+
+  private
+
+  def assign_numbers
+    service = Numbers::GenerateService.new(account: account)
+    self.customer_no ||= service.next_customer_no
+    self.job_no ||= service.next_job_no
+  end
+end

--- a/app/services/numbers/generate_service.rb
+++ b/app/services/numbers/generate_service.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Numbers
+  class GenerateService < ApplicationService
+    option :account
+
+    def next_customer_no
+      (account.leads.maximum(:customer_no) || 0) + 1
+    end
+
+    def next_job_no
+      (account.leads.maximum(:job_no) || 0) + 1
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
     # V1
     namespace :v1 do
       draw :authentication
+      draw :leads
     end
   end
 end

--- a/config/routes/leads.rb
+++ b/config/routes/leads.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+resources :leads, only: %i[index create]

--- a/db/migrate/20240701002000_create_leads.rb
+++ b/db/migrate/20240701002000_create_leads.rb
@@ -1,0 +1,24 @@
+class CreateLeads < ActiveRecord::Migration[7.0]
+  def change
+    create_table :leads do |t|
+      t.references :account, null: false, foreign_key: true
+      t.references :rep, null: false, foreign_key: { to_table: :users }
+      t.string :project_name, null: false
+      t.string :job_type, null: false
+      t.string :spa_type, null: false
+      t.boolean :vanishing_edge, default: false, null: false
+      t.date :client_request_date, null: false
+      t.string :site_address, null: false
+      t.string :customer_name, null: false
+      t.string :customer_phone, null: false
+      t.string :customer_email, null: false
+      t.string :council, null: false
+      t.integer :customer_no, null: false
+      t.integer :job_no, null: false
+      t.timestamps
+    end
+
+    add_index :leads, [:account_id, :customer_no], unique: true
+    add_index :leads, [:account_id, :job_no], unique: true
+  end
+end

--- a/test/factories/leads_factory.rb
+++ b/test/factories/leads_factory.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :lead do
+    account { Current.account || association(:account) }
+    association :rep, factory: :user, account: account
+    project_name { 'Test Project' }
+    job_type { 'installation' }
+    spa_type { 'standard' }
+    vanishing_edge { false }
+    client_request_date { Date.today }
+    site_address { '123 Street' }
+    customer_name { 'John Doe' }
+    customer_phone { '1234567890' }
+    customer_email { 'john@example.com' }
+    council { 'City Council' }
+  end
+end

--- a/test/models/lead_test.rb
+++ b/test/models/lead_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class LeadTest < ActiveSupport::TestCase
+  test 'should have a valid factory' do
+    assert create(:lead).persisted?
+  end
+
+  should belong_to(:account)
+  should belong_to(:rep)
+
+  should validate_presence_of(:project_name)
+  should validate_presence_of(:job_type)
+  should validate_presence_of(:spa_type)
+  should validate_presence_of(:rep)
+  should validate_presence_of(:client_request_date)
+  should validate_presence_of(:site_address)
+  should validate_presence_of(:customer_name)
+  should validate_presence_of(:customer_phone)
+  should validate_presence_of(:customer_email)
+  should validate_presence_of(:council)
+
+  test 'assigns sequential numbers per account' do
+    account = create(:account)
+    Current.account = account
+    lead1 = create(:lead, account: account)
+    lead2 = create(:lead, account: account)
+    assert_equal 1, lead1.customer_no
+    assert_equal 2, lead2.customer_no
+    assert_equal 1, lead1.job_no
+    assert_equal 2, lead2.job_no
+  end
+end


### PR DESCRIPTION
## Summary
- add Lead model, controller and routes
- ensure sequential customer/job numbers per account
- cover with basic model tests

## Testing
- `bundle exec rails db:migrate` (fails: bundler: command not found: rails)
- `bundle exec rails test` (fails: bundler: command not found: rails)


------
https://chatgpt.com/codex/tasks/task_e_689c46cdea208326a72f2149eafaf8fd