### PR TITLE
Add proposal management models with totals

### DIFF
--- a/app/models/lead.rb
+++ b/app/models/lead.rb
@@ -4,6 +4,7 @@ class Lead < ApplicationRecord
   include AccountScoped
 
   belongs_to :rep, class_name: 'User'
+  has_many :proposals, dependent: :destroy
 
   validates :project_name, :job_type, :spa_type, :rep, :client_request_date,
             :site_address, :customer_name, :customer_phone, :customer_email,

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class Proposal < ApplicationRecord
+  include AccountScoped
+
+  belongs_to :lead
+  has_many :proposal_sections, dependent: :destroy
+  has_many :proposal_items, through: :proposal_sections
+
+  validates :issue_number, presence: true
+  validates :status, presence: true
+  validates :adjustment_type, presence: true
+  validates :adjustment_percentage, presence: true
+
+  enum status: {
+    draft: 'draft',
+    sent: 'sent',
+    approved: 'approved',
+    rejected: 'rejected'
+  }, _suffix: true
+
+  enum adjustment_type: {
+    none: 'none',
+    under: 'under',
+    over: 'over'
+  }, _suffix: true
+
+  def total
+    proposal_sections.sum(&:subtotal)
+  end
+
+  def options_total
+    proposal_sections.sum(&:options_total)
+  end
+
+  def adjusted_total
+    case adjustment_type
+    when 'under'
+      total - (total * adjustment_percentage / 100)
+    when 'over'
+      total + (total * adjustment_percentage / 100)
+    else
+      total
+    end
+  end
+
+  def grand_total
+    adjusted_total + options_total
+  end
+end

--- a/app/models/proposal_item.rb
+++ b/app/models/proposal_item.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ProposalItem < ApplicationRecord
+  include AccountScoped
+
+  belongs_to :proposal_section
+
+  validates :description, presence: true
+  validates :quantity, presence: true
+  validates :unit_price, presence: true
+
+  def total_price
+    quantity * unit_price
+  end
+end

--- a/app/models/proposal_section.rb
+++ b/app/models/proposal_section.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class ProposalSection < ApplicationRecord
+  include AccountScoped
+
+  belongs_to :proposal
+  has_many :proposal_items, dependent: :destroy
+
+  validates :title, presence: true
+
+  def subtotal
+    proposal_items.reject(&:optional?).sum(&:total_price)
+  end
+
+  def options_total
+    proposal_items.select(&:optional?).sum(&:total_price)
+  end
+end

--- a/db/migrate/20240701003000_create_proposals.rb
+++ b/db/migrate/20240701003000_create_proposals.rb
@@ -1,0 +1,16 @@
+class CreateProposals < ActiveRecord::Migration[7.0]
+  def change
+    create_table :proposals, id: :uuid do |t|
+      t.references :account, null: false, foreign_key: true, type: :uuid
+      t.references :lead, null: false, foreign_key: true, type: :uuid
+      t.integer :issue_number, null: false, default: 1
+      t.string :status, null: false, default: 'draft'
+      t.string :adjustment_type, null: false, default: 'none'
+      t.decimal :adjustment_percentage, precision: 5, scale: 2, null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :proposals, [:lead_id, :issue_number], unique: true
+  end
+end

--- a/db/migrate/20240701004000_create_proposal_sections.rb
+++ b/db/migrate/20240701004000_create_proposal_sections.rb
@@ -1,0 +1,13 @@
+class CreateProposalSections < ActiveRecord::Migration[7.0]
+  def change
+    create_table :proposal_sections, id: :uuid do |t|
+      t.references :account, null: false, foreign_key: true, type: :uuid
+      t.references :proposal, null: false, foreign_key: true, type: :uuid
+      t.string :title, null: false
+      t.integer :position
+      t.datetime :completed_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240701005000_create_proposal_items.rb
+++ b/db/migrate/20240701005000_create_proposal_items.rb
@@ -1,0 +1,15 @@
+class CreateProposalItems < ActiveRecord::Migration[7.0]
+  def change
+    create_table :proposal_items, id: :uuid do |t|
+      t.references :account, null: false, foreign_key: true, type: :uuid
+      t.references :proposal_section, null: false, foreign_key: true, type: :uuid
+      t.string :item_code
+      t.text :description, null: false
+      t.decimal :quantity, precision: 10, scale: 2, null: false, default: 1
+      t.decimal :unit_price, precision: 10, scale: 2, null: false, default: 0
+      t.boolean :optional, null: false, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_01_001000) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_01_005000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -71,6 +71,75 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_01_001000) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  create_table "leads", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "account_id", null: false
+    t.uuid "rep_id", null: false
+    t.string "project_name", null: false
+    t.string "job_type", null: false
+    t.string "spa_type", null: false
+    t.boolean "vanishing_edge", default: false, null: false
+    t.date "client_request_date", null: false
+    t.string "site_address", null: false
+    t.string "customer_name", null: false
+    t.string "customer_phone", null: false
+    t.string "customer_email", null: false
+    t.string "council", null: false
+    t.integer "customer_no", null: false
+    t.integer "job_no", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id", "customer_no"], name: "index_leads_on_account_id_and_customer_no", unique: true
+    t.index ["account_id", "job_no"], name: "index_leads_on_account_id_and_job_no", unique: true
+  end
+
+  create_table "proposals", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "account_id", null: false
+    t.uuid "lead_id", null: false
+    t.integer "issue_number", default: 1, null: false
+    t.string "status", default: "draft", null: false
+    t.string "adjustment_type", default: "none", null: false
+    t.decimal "adjustment_percentage", precision: 5, scale: 2, default: "0.0", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_proposals_on_account_id"
+    t.index ["lead_id", "issue_number"], name: "index_proposals_on_lead_id_and_issue_number", unique: true
+    t.index ["lead_id"], name: "index_proposals_on_lead_id"
+  end
+
+  create_table "proposal_sections", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "account_id", null: false
+    t.uuid "proposal_id", null: false
+    t.string "title", null: false
+    t.integer "position"
+    t.datetime "completed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_proposal_sections_on_account_id"
+    t.index ["proposal_id"], name: "index_proposal_sections_on_proposal_id"
+  end
+
+  create_table "proposal_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "account_id", null: false
+    t.uuid "proposal_section_id", null: false
+    t.string "item_code"
+    t.text "description", null: false
+    t.decimal "quantity", precision: 10, scale: 2, default: "1.0", null: false
+    t.decimal "unit_price", precision: 10, scale: 2, default: "0.0", null: false
+    t.boolean "optional", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_proposal_items_on_account_id"
+    t.index ["proposal_section_id"], name: "index_proposal_items_on_proposal_section_id"
+  end
+
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
   add_foreign_key "users", "accounts"
+  add_foreign_key "leads", "accounts"
+  add_foreign_key "leads", "users", column: "rep_id"
+  add_foreign_key "proposals", "accounts"
+  add_foreign_key "proposals", "leads"
+  add_foreign_key "proposal_sections", "accounts"
+  add_foreign_key "proposal_sections", "proposals"
+  add_foreign_key "proposal_items", "accounts"
+  add_foreign_key "proposal_items", "proposal_sections"
 end

--- a/test/factories/proposal_items_factory.rb
+++ b/test/factories/proposal_items_factory.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :proposal_item do
+    account { Current.account || association(:account) }
+    association :proposal_section
+    item_code { 'CODE' }
+    description { 'Item description' }
+    quantity { 1 }
+    unit_price { 100 }
+    optional { false }
+  end
+end

--- a/test/factories/proposal_sections_factory.rb
+++ b/test/factories/proposal_sections_factory.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :proposal_section do
+    account { Current.account || association(:account) }
+    association :proposal
+    title { 'Section' }
+    position { 1 }
+  end
+end

--- a/test/factories/proposals_factory.rb
+++ b/test/factories/proposals_factory.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :proposal do
+    account { Current.account || association(:account) }
+    association :lead, account: account
+    issue_number { 1 }
+    status { 'draft' }
+    adjustment_type { 'none' }
+    adjustment_percentage { 0 }
+  end
+end

--- a/test/models/proposal_section_test.rb
+++ b/test/models/proposal_section_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ProposalSectionTest < ActiveSupport::TestCase
+  test 'calculates section totals' do
+    section = create(:proposal_section)
+    create(:proposal_item, proposal_section: section, quantity: 1, unit_price: 200)
+    create(:proposal_item, proposal_section: section, quantity: 1, unit_price: 50, optional: true)
+
+    assert_equal 200, section.subtotal
+    assert_equal 50, section.options_total
+  end
+end

--- a/test/models/proposal_test.rb
+++ b/test/models/proposal_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ProposalTest < ActiveSupport::TestCase
+  test 'should have a valid factory' do
+    assert create(:proposal).persisted?
+  end
+
+  should belong_to(:lead)
+  should have_many(:proposal_sections)
+  should have_many(:proposal_items)
+
+  test 'calculates totals correctly' do
+    proposal = create(:proposal)
+    section = create(:proposal_section, proposal: proposal)
+    create(:proposal_item, proposal_section: section, quantity: 2, unit_price: 100)
+    create(:proposal_item, proposal_section: section, quantity: 1, unit_price: 50, optional: true)
+    section2 = create(:proposal_section, proposal: proposal)
+    create(:proposal_item, proposal_section: section2, quantity: 1, unit_price: 100)
+
+    assert_equal 300, proposal.total
+    assert_equal 50, proposal.options_total
+    assert_equal 350, proposal.grand_total
+  end
+end


### PR DESCRIPTION
## Summary
- add Proposal, ProposalSection, and ProposalItem models with associations
- compute proposal totals including optional items and adjustments
- cover section and proposal totals with tests

## Testing
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*
- `bundle exec rails test` *(fails: bundler: command not found: rails)*

------
https://chatgpt.com/codex/tasks/task_e_689c48dd9a388326a5593e1699cb1d2b